### PR TITLE
QR Code Frontend finish

### DIFF
--- a/server/main/static/css/qrcode.css
+++ b/server/main/static/css/qrcode.css
@@ -3,5 +3,12 @@ h1, h3, div {
 }
 img {
     max-width: 100%;
-    height: auto;
+    max-height: 80vh;
+}
+
+#container {
+    width: 80vw;
+    height: 80vh;
+    display: flex;
+    align-items: center;
 }

--- a/server/main/templates/main/qrcode.html
+++ b/server/main/templates/main/qrcode.html
@@ -7,14 +7,13 @@
         <link rel="stylesheet" href="{% static 'css/qrcode.css' %}">
     </head>
     <body>
-        <h1>
-            You Are Not Registered.
-        </h1>
-        <h3>
-            Please register your card via QR Code below.
-        </h3>
-        <div>
-            <img src="/static/qrimg/{{ img_name }}">
+        <div id='container'>
+            <h1>
+                Register Here ->
+            </h1>
+            <div >
+                <img src="/static/qrimg/{{ img_name }}">
+            </div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
이전 코드에서는 라즈베리 파이 스크린이 480x320 이라서 QR 코드가 짤리는 현상이 있었다.(세로길이가 짧아서 이미지가 짤림) 따라서 html에 있는 아이템을 가로로 변경하고, 이미지 사이즈를 스크린 크기에 따라 변경하도록 변경하였다.

또한 화면 해상도가 안좋을 것을 예상해서 글씨를 많이 줄였다...