### PR TITLE
Set CSRF COOKIE DOMAIN

### DIFF
--- a/server/jaram_atd/settings/production.py
+++ b/server/jaram_atd/settings/production.py
@@ -14,3 +14,4 @@ DATABASES = {
     'default': SETTING_PRD_DIC['DATABASES']["default"]
 }
 
+CSRF_COOKIE_DOMAIN = "attendance.jaram.net"


### PR DESCRIPTION
https 로 POST request를 보낼 때에는 장고가 https 헤더에서 referer를 미들웨어가 검사하는데 이게 헤더에 안넣고 보내면서 오류가 생김.... 미들웨어쪽에서 검증에 실패하게 되므로 COOKIE DOMAIN을 설정해줘야 됨